### PR TITLE
feat: support for handling rollbacks

### DIFF
--- a/internal/miner/miner.go
+++ b/internal/miner/miner.go
@@ -279,7 +279,7 @@ func (m *Miner) Start() {
 		trie := storage.GetStorage().Trie()
 		trie.Lock()
 		tmpHashKey := storage.HashValue(targetHash).Bytes()
-		if err := trie.Update(tmpHashKey, targetHash); err != nil {
+		if err := trie.Update(tmpHashKey, targetHash, 0); err != nil {
 			panic(fmt.Sprintf("failed to update storage for trie: %s", err))
 		}
 		postDatum = models.TunaV2State{


### PR DESCRIPTION
This works by adding additional "added" and "deleted" keys for each UTxO key to track the slot that each UTxO was added or deleted. On a rollback, the slot numbers in these keys will be compared to the rollback slot, and UTxOs will be added/removed accordingly.

Fixes #218 
Fixes #215
Fixes #167