### PR TITLE
chore: update go version to 1.25

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,9 @@ name: publish
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 concurrency: ${{ github.ref }}
 
@@ -16,7 +16,7 @@ jobs:
     outputs:
       RELEASE_ID: ${{ steps.create-release.outputs.result }}
     steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
         id: create-release
         if: startsWith(github.ref, 'refs/tags/')
@@ -76,13 +76,13 @@ jobs:
       packages: write
       statuses: write
     steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
 
@@ -92,16 +92,16 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' }}
         with:
           java-version: 17
-          distribution: 'temurin'
-      - id: 'auth'
+          distribution: "temurin"
+      - id: "auth"
         name: Authenticate with Google Cloud
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' }}
-        uses: 'google-github-actions/auth@v3'
+        uses: "google-github-actions/auth@v3"
         with:
-          credentials_json: '${{ secrets.CERTIFICATE_SA_CREDENTIALS }}'
+          credentials_json: "${{ secrets.CERTIFICATE_SA_CREDENTIALS }}"
       - name: Set up Cloud SDK
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' }}
-        uses: 'google-github-actions/setup-gcloud@v3'
+        uses: "google-github-actions/setup-gcloud@v3"
       - name: Sign windows binary
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' }}
         run: |
@@ -193,7 +193,7 @@ jobs:
       - name: Attest binary
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
-          subject-path: 'bluefin'
+          subject-path: "bluefin"
 
   build-images:
     runs-on: ubuntu-latest
@@ -207,10 +207,10 @@ jobs:
       packages: write
       statuses: write
     steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - run: 'echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0
       - name: Set up Docker Buildx

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/bluefin
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.4
+toolchain go1.25.7
 
 require (
 	github.com/Salvionied/apollo v1.6.0


### PR DESCRIPTION
Closes #553 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the project to Go 1.25 and update CI to test on Go 1.25 and 1.26. Releases now build with 1.25.

- **Dependencies**
  - Set `go` to 1.25.0 and `toolchain` to 1.25.7 in `go.mod`.
  - CI now uses `1.25.x` for builds/releases and tests `1.25.x`/`1.26.x`.

- **Migration**
  - Use Go 1.25+ locally to build and run the repo.

<sup>Written for commit 78158efba7f9c941d6486a0b22926ea0eb75c4df. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/bluefin/pull/559?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go language version requirement from 1.24 to 1.25
  * Expanded continuous integration test coverage to validate against Go 1.25.x and 1.26.x versions
  * Updated build and publish workflows to use the latest Go 1.25.x toolchain for binary and container image builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/bluefin/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->